### PR TITLE
Add dag_tables ssh secret

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -71,6 +71,7 @@ jobs:
           additional_private_keys: |
             ${{ secrets.FSE_SSH_PRIVATE_KEY }}
             ${{ secrets.BEVY_CLIPMAP_SSH_PRIVATE_KEY }}
+            ${{ secrets.DAG_TABLES_SSH_PRIVATE_KEY }}
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
I'm not sure if this is the cause, but we are now seeing failures in whirlpool CI to access the dag_tables repo. Looks very similar to: https://github.com/ForesightMiningSoftwareCorporation/infrastructure/issues/36

Fixes: https://github.com/ForesightMiningSoftwareCorporation/infrastructure/issues/44