### PR TITLE
fix: don't fail ci when no tests ran

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -429,5 +429,5 @@ jobs:
             });
 
       - name: Rust Test status
-        if: fromJson(steps.read.outputs.result).custom_outcome.check == 'failure' || fromJson(steps.read.outputs.result).fmt_outcome.check == 'failure' || fromJson(steps.read.outputs.result).check_outcome.check == 'failure' || fromJson(steps.read.outputs.result).clippy_outcome.check == 'failure' || fromJson(steps.read.outputs.result).tests_outcome.test == 'failure'
+        if: steps.read.outputs.result && (fromJson(steps.read.outputs.result).custom_outcome.check == 'failure' || fromJson(steps.read.outputs.result).fmt_outcome.check == 'failure' || fromJson(steps.read.outputs.result).check_outcome.check == 'failure' || fromJson(steps.read.outputs.result).clippy_outcome.check == 'failure' || fromJson(steps.read.outputs.result).tests_outcome.test == 'failure')
         run: exit 1


### PR DESCRIPTION
The v1.2.0 version introduced a bug that triggers when the workflow is run as non-PR