### PR TITLE
fix: switch ci test results to github provided ubuntu image

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -356,11 +356,6 @@ jobs:
   results:
     name: Rust Test Results
     runs-on: ubuntu-latest
-    env:
-      CARGO_HTTP_USER_AGENT: "shipyard ${{ secrets.CARGO_PRIVATE_REGISTRY_TOKEN }}"
-    container:
-      image: ghcr.io/foresightminingsoftwarecorporation/rust-test:${{ inputs.toolchain }}
-      options: --user root
     needs: check
     if: always()
     steps:


### PR DESCRIPTION
fixes ForesightMiningSoftwareCorporation/infrastructure/issues/239
dependency of a dependency had a bug around installing jq, this commit has the necessary fix applied