### PR TITLE
feat: path triggers for simple repos

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -37,6 +37,10 @@ on:
         type: string
         default: "."
         description: Working directory to run the cargo command
+      crates-directory:
+        type: string
+        default: "crates"
+        description: The location of sub-crates inside the working directory
       custom_cargo_commands:
         type: string
         default: ""
@@ -68,20 +72,66 @@ env:
   CARGO_HTTP_USER_AGENT: "shipyard ${{ secrets.CARGO_PRIVATE_REGISTRY_TOKEN }}"
 
 jobs:
+  build-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Test Matrix
+        id: build
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "matrix=[\".\"]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          git fetch origin ${{ github.base_ref }}
+          git_diff=$(git diff --name-only -r origin/${{ github.base_ref }} HEAD)
+
+          if [ "${{ runner.debug }}" = "1" ]; then
+            git diff --name-only -r origin/${{ github.base_ref }} HEAD
+          fi
+
+          workspace_changed="";
+          workspace_changed+=$(git diff --name-only --relative origin/main HEAD -- src)
+          workspace_changed+=$(git diff --name-only --relative origin/main HEAD -- Cargo.toml)
+
+          if [ "$workspace_changed" != "" ]; then
+            echo "matrix=[\".\"]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          changed_paths=($(git diff --name-only -r origin/${{ github.base_ref }} HEAD | \
+                           grep "^${{ inputs.crates-directory }}/" | cut -d / -f 2 | sort | uniq | xargs))
+          output_paths=''
+          for changed_path in "${changed_paths[@]}"; do
+            output_paths+=",\"${{ inputs.crates-directory }}/$changed_path\""
+          done
+
+          if [ output_paths = '' ]; then
+            output_paths=",\".\""
+          fi
+
+          echo "matrix=[${output_paths:1}]" >> $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+
   check:
     name: Rust ${{ matrix.type }}
     runs-on: [self-hosted, gpu]
+    needs: build-matrix
     env:
       CARGO_HTTP_USER_AGENT: "shipyard ${{ secrets.CARGO_PRIVATE_REGISTRY_TOKEN }}"
     strategy:
       matrix:
+        type: [check, test, miri]
+        path: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
         include:
           - toolchain: ${{ inputs.toolchain }}
-            type: check
-          - toolchain: ${{ inputs.toolchain }}
-            type: test
-          - toolchain: ${{ inputs.nightly_toolchain }}
-            type: miri
+          - type: miri
+            toolchain: ${{ inputs.nightly_toolchain }}
       fail-fast: ${{ inputs.fail-fast == 'true' }}
     steps:
       - name: Configure Git to use global ignore file
@@ -127,7 +177,7 @@ jobs:
       - name: Additional Script
         run: ${{ inputs.additional_script }}
         shell: bash
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
 
       - name: Update Packages
         if: inputs.required_packages != ''
@@ -143,7 +193,7 @@ jobs:
       - name: Get crate name
         id: name
         shell: bash
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
         run: |
           echo "value=$(tomlq package.name -f Cargo.toml)" >> $GITHUB_OUTPUT
 
@@ -159,7 +209,7 @@ jobs:
         continue-on-error: true
         with:
           command: ${{ inputs.custom_cargo_commands }}
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -172,7 +222,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || inputs.custom_cargo_commands == '' || steps.custom.outcome == 'success')
         with:
           command: "cargo fmt --verbose --all -- --check"
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -183,8 +233,8 @@ jobs:
         id: check
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.fmt.outcome == 'success')
         with:
-          command: "cargo check ${{ inputs.additional_args }}"
-          working-directory: ${{ inputs.working-directory }}
+          command: "cargo check ${{ matrix.path == '.' && '--workspace' || '' }} ${{ inputs.additional_args }}"
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -195,8 +245,8 @@ jobs:
         id: clippy
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.check.outcome == 'success' && !cancelled())
         with:
-          command: "cargo clippy ${{ inputs.additional_args }} -- -D warnings"
-          working-directory: ${{ inputs.working-directory }}
+          command: "cargo clippy ${{ matrix.path == '.' && '--workspace' || '' }} ${{ inputs.additional_args }} -- -D warnings"
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -209,7 +259,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
           command: 'RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace'
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -217,7 +267,7 @@ jobs:
 
       - name: Copy Default deny if not exists
         shell: bash
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         run: |
           if [ ! -f deny.toml ]; then
@@ -231,7 +281,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
           command: "cargo deny check licenses"
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -244,7 +294,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
           command: "cargo deny check bans"
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -257,7 +307,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
           command: "cargo deny check advisories"
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -270,7 +320,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
           command: "cargo deny check sources"
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -283,7 +333,7 @@ jobs:
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
           command: "cargo machete"
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -295,8 +345,8 @@ jobs:
         continue-on-error: true
         if: matrix.type == 'check' && (inputs.fail-fast == 'false' || steps.clippy.outcome == 'success' && !cancelled())
         with:
-          command: "cargo package ${{ inputs.additional_args }}"
-          working-directory: ${{ inputs.working-directory }}
+          command: "cargo package ${{ matrix.path == '.' && '--workspace' || '' }} ${{ inputs.additional_args }}"
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -307,8 +357,8 @@ jobs:
         id: tests
         if: matrix.type == 'test' && inputs.skip-cargo-test == 'false' && (inputs.fail-fast == 'false' || !cancelled())
         with:
-          command: "cargo test ${{ inputs.fail-fast == 'false' && '--keep-going' || '' }} ${{ inputs.additional_args }}"
-          working-directory: ${{ inputs.working-directory }}
+          command: "cargo test ${{ inputs.fail-fast == 'false' && '--keep-going' || '' }} ${{ matrix.path == '.' && '--workspace' || '' }} ${{ inputs.additional_args }}"
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -320,8 +370,8 @@ jobs:
         continue-on-error: true
         if: matrix.type == 'miri' && inputs.skip-cargo-test == 'false' && inputs.skip-miri-test == 'false' && (inputs.fail-fast == 'false' || !cancelled())
         with:
-          command: "cargo miri test ${{ inputs.fail-fast == 'false' && '--keep-going' || '' }} ${{ inputs.additional_args }}"
-          working-directory: ${{ inputs.working-directory }}
+          command: "cargo miri test ${{ inputs.fail-fast == 'false' && '--keep-going' || '' }} ${{ matrix.path == '.' && '--workspace' || '' }} ${{ inputs.additional_args }}"
+          working-directory: "${{ inputs.working-directory }}/${{ matrix.path }}"
           loki_url: ${{ vars.LOKI_URL }}
           loki_username: ${{ secrets.LOKI_GITHUB_USERNAME }}
           loki_password: ${{ secrets.LOKI_GITHUB_PASSWORD }}
@@ -329,10 +379,10 @@ jobs:
 
       - uses: cloudposse/github-action-matrix-outputs-write@0.4.2
         id: out
-        if: always() && github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: always()
         with:
           matrix-step-name: ${{ github.job }}
-          matrix-key: ${{ matrix.type }}
+          matrix-key: ${{ matrix.path }}-${{ matrix.type }}
           outputs: |-
             check_outcome: ${{ steps.check.outcome }}
             clippy_outcome: ${{ steps.clippy.outcome }}
@@ -358,12 +408,12 @@ jobs:
     steps:
       - name: Set end time as env variable
         id: end_time
-        if: always() && github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: always()
         run: echo "value=$(date +'%s')000" >> $GITHUB_OUTPUT
 
       - uses: cloudposse/github-action-matrix-outputs-read@0.1.1
         id: read
-        if: always() && github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: always()
         with:
           matrix-step-name: check
 
@@ -375,8 +425,10 @@ jobs:
 
       - uses: actions/github-script@v6
         name: Report status on PR
-        if: always() && github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        id: comment
+        if: always()
         with:
+          result-encoding: string
           script: |
             function outcomeEmoji(outcome) {
               switch (outcome) {
@@ -393,51 +445,79 @@ jobs:
               }
             }
 
-            const header = `
-              <h3>${{ fromJson(steps.read.outputs.result).name.check }} - ${{ (fromJson(steps.read.outputs.result).fmt_outcome.check != 'success' || fromJson(steps.read.outputs.result).check_outcome.check != 'success' || fromJson(steps.read.outputs.result).clippy_outcome.check != 'success' || fromJson(steps.read.outputs.result).tests_outcome.test != 'success' || (inputs.test-publish-required == 'true' && fromJson(steps.read.outputs.result).publish-dryrun_outcome.check != 'success')) && '❌' || '✅' }} ${{ fromJson(steps.read.outputs.result).name.check }}</h3>
-              <table>
-                <tr><th>required</th><th>step</th><th>result</th><th>details</th></tr>
+            function is_success(...args) {
+              return args.reduce((acc, x) => acc && (x === 'success'), true);
+            }
+
+            const result_string = `${{ steps.read.outputs.result }}`;
+            const data = JSON.parse(result_string);
+            const first_val = data['check_outcome'];
+            const paths = [...new Set(Object.keys(first_val).map(key => key.split('-')[0]))].sort();
+
+            let test_output = '';
+            const table_footer = '</table>\n';
+            let start_time = '';
+            let success = true;
+
+            for (let path of paths) {
+
+              const fetch_string = (name, type) => data[name]['' + path + '-' + type];
+
+              start_time = fetch_string('start', 'check');
+
+              const entry = (name, outcome, required, logId) => `
+            <tr>
+            <td align="center">${ required ? '✓' : '' }</td>
+            <td>${ name }</td>
+            <td>${ outcomeEmoji(outcome) }</td>
+            <td><a href="${{vars.GRAFANA_URL}}/d/${{vars.ACTION_LOG_DASHBOARD_ID}}var-run_id=${{ github.run_id }}&var-test=${ logId }&from=${ start_time }&to=${{ steps.end_time.outputs.value }}">Logs</a></td>
+            </tr>
             `;
 
-            const entry = (name, outcome, required, logId) => `
-              <tr>
-                <td align="center">${ required ? '✓' : '' }</td>
-                <td>${ name }</td>
-                <td>${ outcomeEmoji(outcome) }</td>
-                <td><a href="${{vars.GRAFANA_URL}}/d/${{vars.ACTION_LOG_DASHBOARD_ID}}var-run_id=${{ github.run_id }}&var-test=${ logId }&from=${{ fromJson(steps.read.outputs.result).start.check }}&to=${{ steps.end_time.outputs.value }}">Logs</a></td>
-              </tr>
+              const custom = entry('Custom: ${{ inputs.custom_cargo_commands }}', fetch_string('custom_outcome', 'check'), true, 'custom');
+              const fmt = entry('cargo fmt --verbose --all -- --check', fetch_string('fmt_outcome', 'check'), true, 'fmt');
+              const check = entry(`cargo check ${ path === '.' && '--workspace' || '' } ${{ inputs.additional_args }}`, fetch_string('check_outcome', 'check'), true, 'check');
+              const clippy = entry(`cargo clippy ${ path === '.' && '--workspace' || '' } ${{ inputs.additional_args }} -- -D warnings`, fetch_string('clippy_outcome', 'check'), true, 'clippy');
+              const doc = entry('cargo doc', fetch_string('doc_outcome', 'check'), false, 'doc');
+              const licenses = entry('cargo deny check licenses', fetch_string('deny-license_outcome', 'check'), false, 'deny-license');
+              const bans = entry('cargo deny check bans', fetch_string('deny-bans_outcome', 'check'), false, 'deny-bans');
+              const advisories = entry('cargo deny check advisories', fetch_string('deny-advisories_outcome', 'check'), false, 'deny-advisories');
+              const sources = entry('cargo deny check sources', fetch_string('deny-sources_outcome', 'check'), false, 'deny-sources');
+              const machete = entry('cargo machete', fetch_string('dependencies_outcome', 'check'), false, 'dependencies');
+              const test = entry(`cargo test ${ path === '.' && '--workspace' || '' } ${{ inputs.additional_args }}`, fetch_string('tests_outcome', 'test'), true, 'tests');
+              const miri = entry(`cargo miri test ${ path === '.' && '--workspace' || '' } ${{ inputs.additional_args }}`, fetch_string('miri_outcome', 'miri'), false, 'miri');
+              const publish = entry(`cargo publish --dry-run ${ path === '.' && '--workspace' || '' } ${{ inputs.additional_args }}`, fetch_string('publish-dryrun_outcome', 'check'), ${{ inputs.test-publish-required == 'true' }}, 'publish-dryrun');
+
+              const path_success = is_success(fetch_string('fmt_outcome', 'check'), fetch_string('check_outcome', 'check'), fetch_string('clippy_outcome', 'check'), fetch_string('tests_outcome', 'test'), (${{ inputs.test-publish-required }} ? fetch_string('publish-dryrun_outcome', 'check') : 'success'));
+
+              test_output += `
+            <h3>${ fetch_string('name', 'check') } - ${ path_success ? '✅' : '❌' }</h3>
+            <table>
+            <tr><th>required</th><th>step</th><th>result</th><th>details</th></tr>
             `;
-            const custom = entry('Custom: ${{ inputs.custom_cargo_commands }}', '${{ fromJson(steps.read.outputs.result).custom_outcome.check }}', true, 'custom');
-            const fmt = entry('cargo fmt --verbose --all -- --check', '${{ fromJson(steps.read.outputs.result).fmt_outcome.check }}', true, 'fmt');
-            const check = entry('cargo check ${{ inputs.additional_args }}', '${{ fromJson(steps.read.outputs.result).check_outcome.check }}', true, 'check');
-            const clippy = entry('cargo clippy ${{ inputs.additional_args }} -- -D warnings', '${{ fromJson(steps.read.outputs.result).clippy_outcome.check }}', true, 'clippy');
-            const doc = entry('cargo doc', '${{ fromJson(steps.read.outputs.result).doc_outcome.check }}', false, 'doc');
-            const licenses = entry('cargo deny check licenses', '${{ fromJson(steps.read.outputs.result).deny-license_outcome.check }}', false, 'deny-license');
-            const bans = entry('cargo deny check bans', '${{ fromJson(steps.read.outputs.result).deny-bans_outcome.check }}', false, 'deny-bans');
-            const advisories = entry('cargo deny check advisories', '${{ fromJson(steps.read.outputs.result).deny-advisories_outcome.check }}', false, 'deny-advisories');
-            const sources = entry('cargo deny check sources', '${{ fromJson(steps.read.outputs.result).deny-sources_outcome.check }}', false, 'deny-sources');
-            const machete = entry('cargo machete', '${{ fromJson(steps.read.outputs.result).dependencies_outcome.check }}', false, 'dependencies');
-            const test = entry('cargo test ${{ inputs.additional_args }}', '${{ fromJson(steps.read.outputs.result).tests_outcome.test }}', true, 'tests');
-            const miri = entry('cargo miri test ${{ inputs.additional_args }}', '${{ fromJson(steps.read.outputs.result).miri_outcome.miri }}', false, 'miri');
-            const publish = entry('cargo publish --dry-run ${{ inputs.additional_args }}', '${{ fromJson(steps.read.outputs.result).publish-dryrun_outcome.check }}', ${{ inputs.test-publish-required == 'true' }}, 'publish-dryrun');
+              test_output += custom + fmt + check + clippy + doc + licenses + bans + advisories + sources + machete + test + miri + publish;
+              test_output += table_footer;
+              success &= path_success;
+            }
 
             const footer = `
-              </table>
-
-              Pushed by: ${{ github.actor }}, Action: ${{ github.event_name }};
-              Run: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">${{ github.run_id }}</a>
-              Logs: <a href="${{vars.GRAFANA_URL}}/d/${{vars.ACTION_LOG_DASHBOARD_ID}}var-run_id=${{ github.run_id }}&var-test=All&from=${{ fromJson(steps.read.outputs.result).start.check }}&to=${{ steps.end_time.outputs.value }}">Logs</a>
+            Pushed by: ${{ github.actor }}, Action: ${{ github.event_name }};
+            Run: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">${{ github.run_id }}</a>
+            Logs: <a href="${{vars.GRAFANA_URL}}/d/${{vars.ACTION_LOG_DASHBOARD_ID}}var-run_id=${{ github.run_id }}&var-test=All&from=${ start_time }&to=${{ steps.end_time.outputs.value }}">Logs</a>
             `;
 
-            const output = header + custom + fmt + check + clippy + doc + licenses + bans + advisories + sources + machete + test + miri + publish + footer;
+            const output = test_output + footer;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            });
+            if (context.eventName === 'pull_request' || context.eventName === 'pull_request_target') {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            }
+
+            return success ? "0" : "1";
 
       - name: Rust Test status
-        if: steps.read.outputs.result && ((inputs.custom_cargo_commands != '' && fromJson(steps.read.outputs.result).custom_outcome.check != 'success') || fromJson(steps.read.outputs.result).fmt_outcome.check != 'success' || fromJson(steps.read.outputs.result).check_outcome.check != 'success' || fromJson(steps.read.outputs.result).clippy_outcome.check != 'success' || fromJson(steps.read.outputs.result).tests_outcome.test != 'success' || (inputs.test-publish-required == 'true' && fromJson(steps.read.outputs.result).publish-dryrun_outcome.check != 'success'))
-        run: exit 1
+        run: exit ${{ steps.comment.outputs.result }}


### PR DESCRIPTION
This is the first part of the required changes for ForesightMiningSoftwareCorporation/infrastructure/issues/152.

It implements simple path triggers for sub crates in a PR, allowing tests to be skipped when no code was changed in those crates.

This cannot be tagged as `v1` without changes to existing repositories. This PR automatically appends `--workspace` to cargo commands, which isn't allowed to be specified multiple times. Some repos specify it in their `inputs.additional-arguments` and that needs to be removed. Instead, the `inputs.crates-directory` should be properly specified.

See ForesightMiningSoftwareCorporation/ci_tests/pull/20 for outputs and test runs.

Missing in this PR is support for multi-workspace monorepos. A workaround is possible, but requires either disabling github CI checks for tests or losing path triggers again.