### PR TITLE
Update deny.toml for epaint licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,8 @@ allow = [
     "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
+    "OFL-1.1",
+    "LicenseRef-UFL-1.0",
 ]
 unused-allowed-license = "allow"
 [licenses.private]


### PR DESCRIPTION
epaint uses OFL -1.1 and LicenseRef-UFL-1.0 licenses on top of MIT or Apache so we need to allow them. We use epaint in a few places so we need to allow this globally