### PR TITLE
fix(rust-test): Deploy Postgres via service container

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -121,16 +121,25 @@ jobs:
           - 10001:10001 # Queue
           - 10002:10002 # Table
         options: --health-cmd "nc -z 127.0.0.1 10000"
+      postgres:
+        # Hack for conditionally enabling the service:
+        # https://github.com/actions/runner/issues/822
+        image: ${{ (inputs.service_database) && 'postgres' || '' }}
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
-      - name: Start Postgres
+      - name: Set DATABASE_URL
         if: inputs.service_database == 'true'
         shell: bash
         run: |
-          service postgresql start
-          pg_isready
-          sudo -u postgres createuser -s -i -d -r -l -w runner
-          sudo -u postgres psql -c "ALTER ROLE runner WITH PASSWORD 'runner';"
-          echo "DATABASE_URL=postgresql://runner:runner@localhost/postgres" >> "$GITHUB_ENV"
+          echo "DATABASE_URL=postgresql://postgres:postgres@postgres/postgres" >> "$GITHUB_ENV"
       - name: Globally configure Git
         shell: bash
         run: |


### PR DESCRIPTION
Since our migration to ARC (Actions Runner Controller), the deployment of Postgres in CI has stopped working. ARC supports service containers, so we switch to using those instead of a manual deployment.